### PR TITLE
fix ReferenceError

### DIFF
--- a/src/handlers/commands.js
+++ b/src/handlers/commands.js
@@ -15,8 +15,8 @@ module.exports = (message) => {
 
     const args = message.content.slice(config.prefix.length).trim().split(/ +/);
     const commandName = args.shift().toLowerCase();
-    const command = client.commands.get(commandName) 
-        || client.commands.find(cmd => cmd.aliases && cmd.aliases.includes(commandName));
+    const command = message.client.commands.get(commandName) 
+        || message.client.commands.find(cmd => cmd.aliases && cmd.aliases.includes(commandName));
     if (!command)
         return;
 


### PR DESCRIPTION
```
3|EventWat | ReferenceError: client is not defined
3|EventWat |     at Client.module.exports (/Users/admin/scanner02/EventWatcher/src/handlers/commands.js:18:21)
3|EventWat |     at Client.emit (events.js:315:20)
3|EventWat |     at MessageCreateAction.handle (/Users/admin/scanner02/EventWatcher/node_modules/discord.js/src/client/actions/MessageCreate.js:31:14)
3|EventWat |     at Object.module.exports [as MESSAGE_CREATE] (/Users/admin/scanner02/EventWatcher/node_modules/discord.js/src/client/websocket/handlers/MESSAGE_CREATE.js:4:32)
3|EventWat |     at WebSocketManager.handlePacket (/Users/admin/scanner02/EventWatcher/node_modules/discord.js/src/client/websocket/WebSocketManager.js:384:31)
3|EventWat |     at WebSocketShard.onPacket (/Users/admin/scanner02/EventWatcher/node_modules/discord.js/src/client/websocket/WebSocketShard.js:444:22)
3|EventWat |     at WebSocketShard.onMessage (/Users/admin/scanner02/EventWatcher/node_modules/discord.js/src/client/websocket/WebSocketShard.js:301:10)
3|EventWat |     at WebSocket.onMessage (/Users/admin/scanner02/EventWatcher/node_modules/ws/lib/event-target.js:132:16)
3|EventWat |     at WebSocket.emit (events.js:315:20)
3|EventWat |     at Receiver.receiverOnMessage (/Users/admin/scanner02/EventWatcher/node_modules/ws/lib/websocket.js:825:20)
```

bork bork you've got a bug